### PR TITLE
Added automatic method to get NUM_OF_CPU_CORES

### DIFF
--- a/bash-collection/monitoring.sh
+++ b/bash-collection/monitoring.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-NUM_OF_CPU_CORES=12
-
 apps1="nginx php5-fpm dovecot memcached SCREEN mono"
 apps2="master clamd smtpd icinga2 "
 
@@ -19,6 +17,7 @@ iotop=$( iotop -b -n 1 | grep "Actual DISK READ" | head -n 1 )
 cpus=($( mpstat -P ALL 1 1 | awk '/Average:/ && $2 ~ /[0-9]/ {printf "%d\n",$3}' ))
 net=$( tail -n 1 /tmp/netstat.log | xargs )
 updates=$( cat /var/lib/update-notifier/updates-available | xargs | cut -d " " -f 1 )
+NUM_OF_CPU_CORES=$( nproc )
 if [[ "$updates" = "" ]]; then
 	updates=0
 fi


### PR DESCRIPTION
Changed the static declaration of NUM_OF_CPU_CORES to an automatically generated number using nproc, and moved it into the section containing the rest of the automatically gen'd variables. Only consideration left is whether to leave it capitalized or not.